### PR TITLE
Use scratch instead of alpine for the final container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@ RUN cargo install --path .
 RUN addgroup -g 1000 -S koblas && \
     adduser -u 1000 -G koblas -S koblas
 
-
 FROM scratch
-
 COPY --from=builder /usr/local/cargo/bin/koblas /koblas
 COPY --from=builder /etc/passwd /etc/passwd
 
@@ -17,7 +15,7 @@ USER koblas
 
 ENV KOBLAS_ADDRESS=0.0.0.0 \
     KOBLAS_PORT=1080 \
-    KOBLAS_USERS_PATH=/users.toml
+    KOBLAS_USERS_PATH=/etc/koblas/users.toml
 
 EXPOSE 1080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,21 @@ WORKDIR /usr/src/koblas
 COPY . .
 RUN cargo install --path .
 
-FROM alpine
-COPY --from=builder /usr/local/cargo/bin/koblas /usr/local/bin/koblas
-
 RUN addgroup -g 1000 -S koblas && \
     adduser -u 1000 -G koblas -S koblas
+
+
+FROM scratch
+
+COPY --from=builder /usr/local/cargo/bin/koblas /koblas
+COPY --from=builder /etc/passwd /etc/passwd
 
 USER koblas
 
 ENV KOBLAS_ADDRESS=0.0.0.0 \
     KOBLAS_PORT=1080 \
-    KOBLAS_USERS_PATH=/etc/koblas/users.toml
+    KOBLAS_USERS_PATH=/users.toml
 
 EXPOSE 1080
 
-ENTRYPOINT ["koblas"]
+ENTRYPOINT ["/koblas"]


### PR DESCRIPTION
I was curious if koblas needs userland tools to function, and it seems it does not.
Consequently, I decided to change the Dockerfile to use `FROM scratch`, rather than `FROM alpine`.
Not only is the final image somewhat smaller (9.62MB vs 17MB), but it also removes tools a successful attacker could use to e.g. escape the container.